### PR TITLE
Use arduino-cli instead of arduino IDE

### DIFF
--- a/serial/Makefile
+++ b/serial/Makefile
@@ -4,27 +4,33 @@ PORT := /dev/cu.SLAB_USBtoUART
 TTY := /dev/tty.SLAB_USBtoUART
 BAUD := 115200
 PROJECT := $(shell basename "$$PWD")
-BUILD_DIR := $(realpath ../build/$(PROJECT))
+BUILD_DIR := ../build/$(PROJECT)
+BUILD_PATH = $(realpath $(BUILD_DIR))
 BOARD_IN_PATH := $(subst :,.,$(BOARD))
+PROJECT_DIR := $(abspath .)
+
+.PHONY: prepare
+prepare:
+	mkdir -p $(abspath $(BUILD_DIR))
+
+.PHONY: compile
+compile: prepare
+	$(ARDUINO) compile -b $(BOARD) \
+		--build-path $(BUILD_PATH) \
+		--build-cache-path $(BUILD_PATH) \
+		$(PROJECT_DIR)
 
 .PHONY: upload
 upload:
-	cp $(BUILD_DIR)/$(PROJECT).ino.partitions.bin $(PROJECT).$(BOARD_IN_PATH).partitions.bin
-	$(ARDUINO) upload -b $(BOARD) -p $(PORT) -t $$PWD
-
-.PHONY: compile
-compile:
-	$(ARDUINO) compile -b $(BOARD) --build-path $(BUILD_DIR) --build-cache-path $(BUILD_DIR) $$PWD
-
-.PHONY: serial
-serial:
-	screen $(TTY) $(BAUD)
+	cp $(BUILD_PATH)/$(PROJECT).ino.partitions.bin $(PROJECT_DIR)/$(PROJECT).$(BOARD_IN_PATH).partitions.bin
+	$(ARDUINO) upload -b $(BOARD) -p $(PORT) -t $(PROJECT_DIR)
 
 .PHONY: clean
 clean:
-	rm -f *.bin
-	rm -f *.elf
+	rm -f $(PROJECT_DIR)/*.bin
+	rm -f $(PROJECT_DIR)/*.elf
 
+.PHONY: all
 all: compile upload clean
 
 .DEFAULT_GOAL := all

--- a/serial/Makefile
+++ b/serial/Makefile
@@ -1,21 +1,30 @@
-ARDUINO := /Applications/Arduino.app/Contents/MacOS/Arduino
-BUILD_DIR := ../build/$(shell basename "$$PWD")
+ARDUINO := arduino-cli
 BOARD := espressif:esp32:m5stack-core-esp32
 PORT := /dev/cu.SLAB_USBtoUART
 TTY := /dev/tty.SLAB_USBtoUART
 BAUD := 115200
-SKETCH = $(shell basename "$$PWD").ino
+PROJECT := $(shell basename "$$PWD")
+BUILD_DIR := $(realpath ../build/$(PROJECT))
+BOARD_IN_PATH := $(subst :,.,$(BOARD))
 
 .PHONY: upload
 upload:
-	$(ARDUINO) --pref build.path=$(BUILD_DIR) --board $(BOARD) --port $(PORT) --upload $(SKETCH)
+	cp $(BUILD_DIR)/$(PROJECT).ino.partitions.bin $(PROJECT).$(BOARD_IN_PATH).partitions.bin
+	$(ARDUINO) upload -b $(BOARD) -p $(PORT) -t $$PWD
 
-.PHONY: verify
-verify:
-	$(ARDUINO) --pref build.path=$(BUILD_DIR) --board $(BOARD) --port $(PORT) --verify $(SKETCH)
+.PHONY: compile
+compile:
+	$(ARDUINO) compile -b $(BOARD) --build-path $(BUILD_DIR) --build-cache-path $(BUILD_DIR) $$PWD
 
-.PHONE: serial
+.PHONY: serial
 serial:
 	screen $(TTY) $(BAUD)
 
-.DEFAULT_GOAL := verify
+.PHONY: clean
+clean:
+	rm -f *.bin
+	rm -f *.elf
+
+all: compile upload clean
+
+.DEFAULT_GOAL := all


### PR DESCRIPTION
`arduino-cli` seems to be more suitable for setting up the arduino dev environment with Make since it's built with golang, not java, and then it finishes whatever tasks much faster than it used to be.

